### PR TITLE
Update the score calculation with output into SQLlite

### DIFF
--- a/src/data/scores.py
+++ b/src/data/scores.py
@@ -1,21 +1,19 @@
 """
 This module can calculate the matching scores using cosine similarity
+and stores results in an SQLite database.
 """
 import json
-import math
-import csv
+import sqlite3
 from pathlib import Path
 from typing import List, Dict
-from tqdm import tqdm  # Nicer progress bars
-
+from tqdm import tqdm
 import numpy as np
 
-def compute_similarities(embeddings_dir: str, output_csv: str) -> None:
+def compute_similarities(embeddings_dir: str, output_db: str) -> None:
     file_paths: List[Path] = list(Path(embeddings_dir).glob("*.json"))
 
-    # We begin by creating a list of all entries
     entries: List[Dict[str, object]] = []
-    for path in tqdm(file_paths, desc="Indexing"):
+    for path in tqdm(file_paths, desc="Loading entries into memory"):
         with open(path, "r", encoding="utf-8") as f:
             data: Dict = json.load(f)
             for entry in data:
@@ -25,24 +23,37 @@ def compute_similarities(embeddings_dir: str, output_csv: str) -> None:
                     "embedding": entry["embedding"]
                 })
 
-    # Now we do the actual calculation.
-    with open(output_csv, "w", newline='', encoding="utf-8") as out_f:
-        writer = csv.writer(out_f)
-        writer.writerow(["id1", "id2", "cosine_similarity"])
+    conn = sqlite3.connect(output_db)
+    cur = conn.cursor()
 
-        for i in tqdm(range(len(entries)), desc="Computing"):
-            id1 = entries[i]["id"]
-            vec1 = entries[i]["embedding"]
-            norm1 = entries[i]["vector_norm"]
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS similarities (
+            id1 TEXT,
+            id2 TEXT,
+            cosine_similarity REAL
+        )
+    """)
+    conn.commit()
 
-            # Since `s_{A,B} == s_{B,A}`, we only have to calculate each pair once
-            for j in range(i + 1, len(entries)):
-                id2 = entries[j]["id"]
-                vec2 = entries[j]["embedding"]
-                norm2 = entries[j]["vector_norm"]
+    for i in tqdm(range(len(entries)), desc="     Computing similarities"):
+        id1 = entries[i]["id"]
+        vec1 = entries[i]["embedding"]
+        norm1 = entries[i]["vector_norm"]
 
-                sim: float = float(np.dot(vec1, vec2) / (norm1 * norm2))
-                writer.writerow([id1, id2, f"{sim:.6f}"])
+        for j in range(i + 1, len(entries)):
+            id2 = entries[j]["id"]
+            vec2 = entries[j]["embedding"]
+            norm2 = entries[j]["vector_norm"]
+
+            sim: float = float(np.dot(vec1, vec2) / (norm1 * norm2))
+            cur.execute("INSERT INTO similarities (id1, id2, cosine_similarity) VALUES (?, ?, ?)",
+                        (id1, id2, sim))
+
+    conn.commit()
+    conn.close()
 
 if __name__ == '__main__':
-    compute_similarities("../../data/embeddings/qwen3", "../../data/scores/scores_qwen3.csv")
+    compute_similarities(
+        "../../data/embeddings/qwen3_eclass_14_and_15",
+        "../../data/scores/scores_qwen3_eclass_14_and_15.sqlite"
+    )


### PR DESCRIPTION
Previously, the scores were saved in a CSV format, which is impractical for the later experiments, as it is very inefficient to query a large CSV file. Instead we now save it to an SQLlite databsae, which can be easily queried.